### PR TITLE
Changes for PEP 8 and readability.

### DIFF
--- a/down.py
+++ b/down.py
@@ -8,9 +8,18 @@ bad = "\033[91m✘\033[0m"
 
 # Header is needed for some sites or else they will think
 # that a bot is accessing the site wont return 200
-headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0'}
+headers = {
+    'User-Agent':
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) '
+        'Gecko/20100101 Firefox/55.0'
+    }
+
 
 def show_help():
+    """
+    Show the help message
+    """
+
     help_message = """
     Usage: python3 down.py [file] [url]
 
@@ -19,34 +28,54 @@ def show_help():
       python3 down.py https://www.example.com
     """
 
-    print(help_message)
+    sys.stdout.write(help_message)
     sys.exit()
 
-def printStatus(up, site):
-    good = "\033[92m✔\033[0m"
-    bad = "\033[91m✘\033[0m"
-    print("{}   {}".format(good if up else bad, site))
+
+def print_status(up, site):
+    """
+    Print the status of the site to stdout
+    :param up: Is the site up? True or False
+    :type up: bool
+    :param site: The site URL
+    :type site: str
+    """
+
+    sys.stdout.write("{}   {}".format(good if up else bad, site))
 
 
 def _file(file):
+    """
+    Check if file exists
+
+    :param file: The path to the file
+    :type file: str
+    """
     try:
         with open(file, "r") as f:
             for site in f:
                 site = site.strip()
                 _url(site)
     except FileNotFoundError:
-        print("No such file: " + file)
+        sys.stdout.write("No such file: {}".format(file))
+
 
 def _url(site):
+    """
+    Check if site is up
+    :param site: The url of the site
+    :type site: str
+    """
     try:
         r = requests.get(site)
         if r.status_code != 200:
-            printStatus(False, site)
+            print_status(False, site)
         else:
-            printStatus(True, site)
-    except:
-        printStatus(False, site)
-        
+            print_status(True, site)
+    except requests.ConnectionError:
+        print_status(False, site)
+
+
 if len(sys.argv) == 1 or sys.argv[1] == "-h":
     show_help()
 
@@ -56,4 +85,3 @@ if sys.argv[1].startswith("http"):
     sys.exit()
 
 _file(sys.argv[1])
-


### PR DESCRIPTION
I have made quite a few changes here to improve complience with [PEP 8](https://www.python.org/dev/peps/pep-0008/), the python style guide.

- I have added comments to each function.
- Changed print() statements to sys.stdout.write() as this is more correct for cli programs. We should really be returning a status code when the program exits to play nice with other cli programs, but one stage at a time eh?
- renamed printStatus() to print_status() in line with PEP 8 naming conventions
- Tested for the correct exception in _url(), again in line with PEP 8.

Feel free to accept any, all or none of these I won't be offended at all, just trying to help a bit.
