### PR TITLE
Refactored code to allow packaging on PyPi. Fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,14 @@
 # :floppy_disk: Installation
 
 ```bash
-# clone the repo
-$ git clone https://github.com/sdushantha/down.git
-
-# install the requirements
-$ pip3 install -r requirements.txt
+$ pip install down
 ```
 
 ## :hammer: Usage
 ```bash
-Usage: python3 down.py [file] [url]
+Usage: down [file] [url]
 
 Example
-  python3 down.py url_list.txt
-  python3 down.py https://www.example.com
+  down url_list.txt
+  down https://www.example.com
 ```

--- a/down/__main__.py
+++ b/down/__main__.py
@@ -1,0 +1,12 @@
+"""
+CLI Entry point
+"""
+from down import down
+
+
+def main():
+    """
+    Get the entry point
+    """
+    down.down()
+

--- a/down/__version__.py
+++ b/down/__version__.py
@@ -1,0 +1,14 @@
+"""
+Version information
+"""
+
+version = '0.0.1'
+
+__title__ = 'down'
+__description__ = 'Check if a site is up or down from cli.'
+__url__ = 'https://github.com/sdushantha/down'
+__version__ = version
+__author__ = 'Siddharth Dushantha'
+__author_email__ = 'siddharth.dushantha@gmail.com'
+__license__ = 'MIT'
+__copyright__ = 'Copyright 2018 Siddarth Dushantha'

--- a/down/down.py
+++ b/down/down.py
@@ -57,7 +57,7 @@ def _file(file):
                 site = site.strip()
                 _url(site)
     except FileNotFoundError:
-        sys.stdout.write("No such file: {}".format(file))
+        sys.stdout.write("No such file: {}\n".format(file))
 
 
 def _url(site):
@@ -76,12 +76,20 @@ def _url(site):
         print_status(False, site)
 
 
-if len(sys.argv) == 1 or sys.argv[1] == "-h":
-    show_help()
+def down():
+    """
+    Entry point to the app.
+    """
+    if len(sys.argv) == 1 or sys.argv[1] == "-h":
+        show_help()
 
-# Checking if url or file    
-if sys.argv[1].startswith("http"):
-    _url(sys.argv[1])
-    sys.exit()
+    # Checking if url or file
+    if sys.argv[1].startswith("http"):
+        _url(sys.argv[1])
+        sys.exit()
 
-_file(sys.argv[1])
+    _file(sys.argv[1])
+
+
+if __name__ == '__main__':
+    down()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-requests

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,39 @@
+"""
+Setup as a package
+"""
+import os
+from setuptools import setup
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+requires = [
+    'requests',
+]
+
+packages = ['down']
+
+about = {}
+with open(os.path.join(here, 'down', '__version__.py')) as f:
+    exec(f.read(), about)
+
+with open('README.md') as f:
+    readme = f.read()
+
+setup(
+        name=about['__title__'],
+        version=about['__version__'],
+        description=about['__description__'],
+        long_description=readme,
+        author=about['__author__'],
+        author_email=about['__author_email__'],
+        url=about['__url__'],
+        license=about['__license__'],
+        entry_points={
+            'console_scripts': [
+                'down = down.__main__:main'
+            ]
+        },
+        package_dir={'down': 'down'},
+        install_requires=requires,
+        packages=packages
+)


### PR DESCRIPTION
- Moved down.py to `down/down.py`
- Created setup.py
- Created `down/__init__.py`
- Created `down/__main__.py`
- Created `down/__version__.py`
- Removed requirements.txt as depes are now in setup.py
- Modified README.md to reflect new installation method and useage

Package now installs with a directly useable comand.
i.e. Just type `down urltotest.com`, rather than `python3 down urltotest.com`

---

Siddarth, to deploy this you will need to create an account on [Pypi](https://pypi.org/).
To deploy you will need to install twine. `pip install twine`

After that you should cd into the top `down` directory and issue the following commands:-

```bash
$ python3 setup.py  sdist bdist-wheel
$ twine upload dist/*
```

You will be asked for your username and password for PyPi and voila! You have distributed a package.

Test everything locally before uploading though.